### PR TITLE
fix: [Articles_essentiels] missing comma - make Bib file parseable

### DIFF
--- a/Articles_essentiels.bib
+++ b/Articles_essentiels.bib
@@ -82,7 +82,7 @@
   pages={87--108},
   year={2018},
   keyword = {datasphère, cyberespace, révolution numérique, géopolitique, diplomatie},
-  url = {https://journals.openedition.org/netcom/3419}
+  url = {https://journals.openedition.org/netcom/3419},
   publisher={Netcom Association}
 }
 

--- a/Biblio_Nov_23.bib
+++ b/Biblio_Nov_23.bib
@@ -290,7 +290,7 @@
     publisher= {O'Reilly},
     keyword={Cyberguerre, Géopolitique}}
 
-    @book{étiquette}
+    @book{étiquette,
     author = {Carrier, Brian},
     title = {File System Forensic Analysis},
     year = {2005},


### PR DESCRIPTION
fix: [Articles_essentiels] missing comma  and incorrect format to make Bib file parseable